### PR TITLE
Add Confirm Signup page and client component for email confirmation flow

### DIFF
--- a/app/confirm-signup/ConfirmSignupClient.tsx
+++ b/app/confirm-signup/ConfirmSignupClient.tsx
@@ -8,6 +8,7 @@ type Props = {
   initialEmail?: string;
   initialError?: string;
   initialErrorDescription?: string;
+  initialConfirmationUrl?: string;
   hasAnyInitialParams: boolean;
 };
 
@@ -21,11 +22,10 @@ function parseHashParams(hash: string): Record<string, string> {
   return result;
 }
 
-export default function ConfirmEmailClient(props: Props) {
+export default function ConfirmSignupClient(props: Props) {
   const [fragmentParams, setFragmentParams] = useState<Record<string, string>>({});
 
   useEffect(() => {
-    // Read fragment on mount and on hash changes
     const read = () => setFragmentParams(parseHashParams(window.location.hash));
     read();
     window.addEventListener("hashchange", read);
@@ -33,7 +33,6 @@ export default function ConfirmEmailClient(props: Props) {
   }, []);
 
   const merged = useMemo(() => {
-    // Fragment params override initial (query) when present
     return {
       access_token: fragmentParams.access_token ?? props.initialAccessToken,
       email: fragmentParams.email ?? props.initialEmail,
@@ -45,13 +44,34 @@ export default function ConfirmEmailClient(props: Props) {
     };
   }, [fragmentParams, props.initialAccessToken, props.initialEmail, props.initialError, props.initialErrorDescription, props.hasAnyInitialParams]);
 
-  const isSuccess = Boolean(merged.access_token);
-  const isError = !isSuccess && (Boolean(merged.error) || !merged.hasAny);
+  const hasPreScreen = Boolean(props.initialConfirmationUrl);
+  const isSuccess = !hasPreScreen && Boolean(merged.access_token);
+  const isError = !hasPreScreen && !isSuccess && (Boolean(merged.error) || !merged.hasAny);
 
   return (
     <main className="min-h-screen font-sans flex items-center">
       <section className="w-full">
         <div className="mx-auto max-w-3xl px-6 py-24 sm:py-32">
+          {hasPreScreen && (
+            <div>
+              <h1
+                className="text-3xl font-bold tracking-tight sm:text-4xl"
+                style={{ color: "var(--color-rochester-blue)" }}
+              >
+                Click this button to confirm your email
+              </h1>
+              <div className="mt-8">
+                <a
+                  href={props.initialConfirmationUrl}
+                  className="rounded-md px-5 py-3 text-sm font-semibold text-white shadow-sm inline-block"
+                  style={{ backgroundColor: "var(--color-rochester-blue)" }}
+                >
+                  Confirm email
+                </a>
+              </div>
+            </div>
+          )}
+
           {isSuccess && (
             <div>
               <h1

--- a/app/confirm-signup/page.tsx
+++ b/app/confirm-signup/page.tsx
@@ -1,6 +1,6 @@
-import ConfirmEmailClient from "./ConfirmEmailClient";
+import ConfirmSignupClient from "./ConfirmSignupClient";
 
-export default async function ConfirmEmailPage({
+export default async function ConfirmSignupPage({
   searchParams,
 }: {
   searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
@@ -14,11 +14,12 @@ export default async function ConfirmEmailPage({
   };
 
   return (
-    <ConfirmEmailClient
+    <ConfirmSignupClient
       initialAccessToken={getParam("access_token")}
       initialEmail={getParam("email")}
       initialError={getParam("error")}
       initialErrorDescription={getParam("error_description")}
+      initialConfirmationUrl={getParam("confirmation_url")}
       hasAnyInitialParams={Object.keys(resolved || {}).length > 0}
     />
   );

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -40,11 +40,12 @@
 - `NEXT_PUBLIC_PLAY_STORE_URL`: Google Play link (e.g., `https://play.google.com/store/apps/details?id=com.example.app`).
 - These are optional; if unset, the UI shows "Coming soon" placeholders.
 
-### Auth Email Confirmation Redirect
-- Route: `/confirm-email` handled by App Router in `app/confirm-email/page.tsx` with a client component merger.
+### Auth Email Confirmation Redirect (confirm-signup)
+- Route: `/confirm-signup` handled by App Router in `app/confirm-signup/page.tsx`.
+- Pre-screen: when `confirmation_url` is present in query params, show heading “Click this button to confirm your email” with a primary action button labeled “Confirm email” linking to the exact `confirmation_url`. This page does not display success or error states.
 - Success: when `access_token` is present in query params or fragment, show “Email confirmed” and “You can now log in with <email>” if `email` is provided; primary CTA links back to homepage.
 - Error: when `error` is present (in query or fragment), or when there are no params, show “Oops, we couldn't confirm your email”, include `error_description` if provided (fallback to “Unknown”), and a mailto support link to `contact@roctrades.com`.
-- Implementation: server component awaits `searchParams`, passes initial values to a client component that also parses URL fragment (`window.location.hash`) and merges values (fragment takes precedence). No tokens are persisted; purely presentational for v0.
+- Implementation: server component awaits `searchParams`, passes initial values (including `confirmation_url`) to a client component that also parses URL fragment (`window.location.hash`) and merges values (fragment takes precedence). No tokens are persisted; purely presentational for v0.
 - Styling/UX: matches brand tokens (`--color-rochester-blue` for actions), semantic headings, and responsive spacing consistent with the hero.
 
 ### What’s NOT in v0

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -1,17 +1,19 @@
 ## E2E Tests
 
-### confirm-email.spec.ts
-- Success with email: `/confirm-email?access_token=abc123&email=student%40rochester.edu`
+### confirm-signup.spec.ts
+- Pre-screen with confirmation_url: `/confirm-signup?confirmation_url=https%3A%2F%2Fexample.com%2Fconfirm%3Ftoken%3Dabc`
+  - Expects heading “Click this button to confirm your email” and a primary action labeled “Confirm email” linking to `https://example.com/confirm?token=abc`.
+- Success with email: `/confirm-signup?access_token=abc123&email=student%40rochester.edu`
   - Expects heading “Email confirmed” and text “You can now log in with student@rochester.edu”.
-- Success without email: `/confirm-email?access_token=abc123`
+- Success without email: `/confirm-signup?access_token=abc123`
   - Expects heading “Email confirmed” and text “You can now log in.”
-- Error with description: `/confirm-email?error=token_expired&error_description=Your%20confirmation%20link%20has%20expired`
+- Error with description: `/confirm-signup?error=token_expired&error_description=Your%20confirmation%20link%20has%20expired`
   - Expects heading “Oops, we couldn't confirm your email”, visible mailto support link, and details “Your confirmation link has expired”.
-- Error without description: `/confirm-email?error=unknown_error`
+- Error without description: `/confirm-signup?error=unknown_error`
   - Expects heading above and details “Unknown”.
-- No params: `/confirm-email`
+- No params: `/confirm-signup`
   - Expects heading above and details “Unknown”.
-- Fragment error params (from auth providers): `/confirm-email#error=access_denied&error_code=otp_expired&error_description=Email%20link%20is%20invalid%20or%20has%20expired`
+- Fragment error params (from auth providers): `/confirm-signup#error=access_denied&error_code=otp_expired&error_description=Email%20link%20is%20invalid%20or%20has%20expired`
   - Expects heading above and details “Email link is invalid or has expired”.
 
 Run:

--- a/tests/confirm-signup.spec.ts
+++ b/tests/confirm-signup.spec.ts
@@ -1,8 +1,18 @@
 import { test, expect } from '@playwright/test';
 
-test.describe('Confirm Email', () => {
+test.describe('Confirm Signup', () => {
+  test('pre-screen shows CTA when confirmation_url is present', async ({ page }) => {
+    await page.goto('/confirm-signup?confirmation_url=https%3A%2F%2Fexample.com%2Fconfirm%3Ftoken%3Dabc');
+    await expect(
+      page.getByRole('heading', { name: 'Click this button to confirm your email' })
+    ).toBeVisible();
+    const link = page.getByRole('link', { name: 'Confirm email' });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute('href', 'https://example.com/confirm?token=abc');
+  });
+
   test('success with email shows confirmation and email text', async ({ page }) => {
-    await page.goto('/confirm-email?access_token=abc123&email=student%40rochester.edu');
+    await page.goto('/confirm-signup?access_token=abc123&email=student%40rochester.edu');
     await expect(page.getByRole('heading', { name: 'Email confirmed' })).toBeVisible();
     await expect(page.getByText('You can now log in with')).toBeVisible();
     await expect(page.getByText('student@rochester.edu')).toBeVisible();
@@ -10,13 +20,13 @@ test.describe('Confirm Email', () => {
   });
 
   test('success without email shows generic confirmation', async ({ page }) => {
-    await page.goto('/confirm-email?access_token=abc123');
+    await page.goto('/confirm-signup?access_token=abc123');
     await expect(page.getByRole('heading', { name: 'Email confirmed' })).toBeVisible();
     await expect(page.getByText('You can now log in.')).toBeVisible();
   });
 
   test('error with description shows message and details', async ({ page }) => {
-    await page.goto('/confirm-email?error=token_expired&error_description=Your%20confirmation%20link%20has%20expired');
+    await page.goto('/confirm-signup?error=token_expired&error_description=Your%20confirmation%20link%20has%20expired');
     await expect(
       page.getByRole('heading', { name: "Oops, we couldn't confirm your email" })
     ).toBeVisible();
@@ -25,7 +35,7 @@ test.describe('Confirm Email', () => {
   });
 
   test('error without description shows Unknown', async ({ page }) => {
-    await page.goto('/confirm-email?error=unknown_error');
+    await page.goto('/confirm-signup?error=unknown_error');
     await expect(
       page.getByRole('heading', { name: "Oops, we couldn't confirm your email" })
     ).toBeVisible();
@@ -33,7 +43,7 @@ test.describe('Confirm Email', () => {
   });
 
   test('no params shows Unknown error', async ({ page }) => {
-    await page.goto('/confirm-email');
+    await page.goto('/confirm-signup');
     await expect(
       page.getByRole('heading', { name: "Oops, we couldn't confirm your email" })
     ).toBeVisible();
@@ -41,7 +51,7 @@ test.describe('Confirm Email', () => {
   });
 
   test('fragment error params show message and details', async ({ page }) => {
-    await page.goto('/confirm-email#error=access_denied&error_code=otp_expired&error_description=Email%20link%20is%20invalid%20or%20has%20expired');
+    await page.goto('/confirm-signup#error=access_denied&error_code=otp_expired&error_description=Email%20link%20is%20invalid%20or%20has%20expired');
     await expect(
       page.getByRole('heading', { name: "Oops, we couldn't confirm your email" })
     ).toBeVisible();


### PR DESCRIPTION
- Introduced `ConfirmSignupClient` component to handle email confirmation logic and display success/error states based on URL parameters.
- Created `ConfirmSignupPage` server component to pass initial parameters to the client component.
- Updated documentation to reflect the new `/confirm-signup` route and its functionality.
- Added end-to-end tests for various scenarios including pre-screen, success, and error states.